### PR TITLE
Use jQuery, jsonp to avoid CORS issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 </head>
 
 <body>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
         <script src="lib/soda-js.bundle.js"></script>
         <script src="lib/map-data.js"></script>
         <script src="lib/dockless-data.js"></script>

--- a/lib/dockless-data.js
+++ b/lib/dockless-data.js
@@ -1,5 +1,5 @@
 var consumer = new soda.Consumer('data.austintexas.gov');
-consumer.query()
+var query = consumer.query()
     .withDataset('7d8e-dm7r')
     .select(['start_time',
         'end_time',
@@ -13,6 +13,10 @@ consumer.query()
     .where({ vehicle_type: 'scooter' }, "end_longitude < -90")
     .order('end_time DESC')
     .limit(200)
-    .getRows()
-    .on('success', function (rows) { createMap(rows); })
-    .on('error', function (error) { console.error(error); });
+
+$.ajax({
+    url: query.getURL(),
+    jsonp: "$jsonp",
+}).done(function(data) {
+    createMap(data);
+});


### PR DESCRIPTION
This change works around CORS issues that users will encounter when using default settings in Safari and other browsers.